### PR TITLE
Use doweights option and add a plotting option

### DIFF
--- a/datareduction/vlbatasks.py
+++ b/datareduction/vlbatasks.py
@@ -5,7 +5,7 @@ from AIPS import AIPS, AIPSDisk
 from AIPSTask import AIPSTask, AIPSList
 from AIPSData import AIPSUVData, AIPSImage, AIPSCat
 from Wizardry.AIPSData import AIPSUVData as WizAIPSUVData
-import matplotlib
+#import matplotlib
 #matplotlib.use('Agg')
 from scipy.special import jn
 import sys, os, subprocess, math, datetime, glob

--- a/datareduction/vlbatasks.py
+++ b/datareduction/vlbatasks.py
@@ -5218,8 +5218,6 @@ def write_difmappsrscript(imagename, bands, difmap, pixsize, finepix,npixels=102
     #difmap.stdin.write("device " + imagename + ".clean.ps/PS\n")
     psfile = imagename.split('/')[-1] +  ".clean.ps"
     os.system("rm -f " + psfile)
-    print(psfile)
-    #difmap.wait()
     difmap.stdin.write("device %s /ps\n" % psfile)
     difmap.stdin.write("mappl cln\n")
     if os.path.exists(imagename):

--- a/datareduction/vlbatasks.py
+++ b/datareduction/vlbatasks.py
@@ -5218,7 +5218,7 @@ def write_difmappsrscript(imagename, bands, difmap, pixsize, finepix,npixels=102
     #difmap.stdin.write("device " + imagename + ".clean.ps/PS\n")
     psfile = imagename.split('/')[-1] +  ".clean.ps"
     os.system("rm -f " + psfile)
-    difmap.stdin.write("device %s /ps\n" % psfile)
+    difmap.stdin.write("device %s/PS\n" % psfile)
     difmap.stdin.write("mappl cln\n")
     if os.path.exists(imagename):
         os.system("rm -f " + imagename)


### PR DESCRIPTION
two totally unrelated change requests here (sorry for that):

1) I've added the option fitld.doweight=1 (in functions that were relevant for my purposes-- others may wish to see whether they want to add this elsewhere too). Setting this to True (=1) causes data weights to be scaled by bandwidth times integration time (i.e. you get meaningful weights). 

2) I've added an option (default None) to provide a list of reference antennae in plotbandpass so that baselines are optionally only plotted if they include an antenna from the list provided. If no list is provided, it will plot all baselines (as before).